### PR TITLE
Show connection errors to the user

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -58,11 +58,16 @@ export const NavBar = (): React.ReactElement => {
       <div className="navbar-right">
         <button
           className="connection-button"
+          role="connect"
           onClick={() => connectIfNeeded(client)}
         >
           {showConnectionState()}
         </button>
-        <button className="settings-button" onClick={toggleSettings}>
+        <button
+          className="settings-button"
+          role="toggleSettings"
+          onClick={toggleSettings}
+        >
           <SettingsSharpIcon className={showSettings ? "open icon" : "icon"} />
         </button>
       </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,14 +4,18 @@ import { connectToWebsocket, WebsocketConnector } from "../websockets";
 import SettingsSharpIcon from "../icons/settingsIcon";
 import BxLinkIcon from "../icons/connectIcon";
 import BxUnlinkIcon from "../icons/disconnectIcon";
+import WarningIcon from "../icons/warningIcon";
 import Logo from "../icons/logo";
 
 export const NavBar = (): React.ReactElement => {
-  const { showSettings, connected, client } = UIStore.useState((s) => ({
-    showSettings: s.clientSettings.showSettings,
-    connected: s.connection.connected,
-    client: s.connection.client,
-  }));
+  const { showSettings, connected, client, connectedState } = UIStore.useState(
+    (s) => ({
+      showSettings: s.clientSettings.showSettings,
+      connected: s.connection.connected,
+      client: s.connection.client,
+      connectedState: s.connection.loadState,
+    })
+  );
   const toggleSettings = () => {
     UIStore.update((s) => {
       s.clientSettings.showSettings = !showSettings;
@@ -25,28 +29,48 @@ export const NavBar = (): React.ReactElement => {
       connectToWebsocket();
     }
   };
+
+  const showConnectionState = (): React.ReactElement => {
+    if (connectedState.type == "error") {
+      return (
+        <React.Fragment>
+          <WarningIcon className="icon" /> {"Disconnected"}
+        </React.Fragment>
+      );
+    } else if (connected) {
+      return (
+        <React.Fragment>
+          <BxLinkIcon className="icon" /> {"Connected"}
+        </React.Fragment>
+      );
+    } else {
+      return (
+        <React.Fragment>
+          <BxUnlinkIcon className="icon" /> {"Disconnected"}
+        </React.Fragment>
+      );
+    }
+  };
+
   return (
     <header className="navbar">
       <Logo className="logo" />
       <div className="navbar-right">
         <button
-          className="connectionButton"
+          className="connection-button"
           onClick={() => connectIfNeeded(client)}
         >
-          {connected ? (
-            <>
-              <BxLinkIcon className="icon" /> {"Connected"}
-            </>
-          ) : (
-            <>
-              <BxUnlinkIcon className="icon" /> {"Disconnected"}
-            </>
-          )}
+          {showConnectionState()}
         </button>
-        <button className="settingsButton" onClick={toggleSettings}>
+        <button className="settings-button" onClick={toggleSettings}>
           <SettingsSharpIcon className={showSettings ? "open icon" : "icon"} />
         </button>
       </div>
+      {connectedState.type == "error" && (
+        <div className="error-message">
+          <p>Error Connecting: {connectedState.error}</p>
+        </div>
+      )}
     </header>
   );
 };

--- a/src/icons/warningIcon.tsx
+++ b/src/icons/warningIcon.tsx
@@ -1,0 +1,18 @@
+// icon:warning | Ant Design Icons https://ant.design/components/icon/ | Ant Design
+import * as React from "react";
+
+function WarningIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 1024 1024"
+      fill="currentColor"
+      height="1em"
+      width="1em"
+      {...props}
+    >
+      <path d="M955.7 856l-416-720c-6.2-10.7-16.9-16-27.7-16s-21.6 5.3-27.7 16l-416 720C56 877.4 71.4 904 96 904h832c24.6 0 40-26.6 27.7-48zM480 416c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v184c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V416zm32 352a48.01 48.01 0 010-96 48.01 48.01 0 010 96z" />
+    </svg>
+  );
+}
+
+export default WarningIcon;

--- a/src/styles/components/Navbar.scss
+++ b/src/styles/components/Navbar.scss
@@ -26,17 +26,26 @@
     .navbar-right {
         display: flex;
 
-        .connectionButton {
+        .connection-button {
             color: $tertiary;
             display: flex;
             align-items: center;
             margin-right: $spacing;
         }
 
-        .settingsButton {
+        .settings-button {
             margin-right: $spacing;
         }
-
+    }
+    .error-message {
+        position: absolute;
+        background: $grey;
+        top: 2.5rem;
+        width: 100%;
+        left: 0;
+        display: flex;
+        justify-content: center;
+        color: $dark;
     }
 }
 

--- a/src/tests/Navbar.test.tsx
+++ b/src/tests/Navbar.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { NavBar } from "../components/Navbar";
+import { UIStore } from "../store";
+
+test("renders navbar in the page", () => {
+  render(<NavBar />);
+
+  const settingsButton = screen.getByRole("toggleSettings");
+  expect(settingsButton).toBeInTheDocument();
+
+  const connectButton = screen.getByRole("connect");
+  expect(connectButton).toBeInTheDocument();
+});
+
+test("clicking settings will open settings", () => {
+  const { container } = render(<NavBar />);
+
+  const settingsButton = screen.getByRole("toggleSettings");
+  expect(settingsButton).toBeInTheDocument();
+
+  fireEvent.click(settingsButton);
+
+  expect(container.getElementsByClassName("open icon").length).toBe(1);
+});
+
+test("clicking connect will show the right state", () => {
+  UIStore.update((s) => {
+    s.connection.connected = true;
+    s.connection.loadState = { type: "connected" };
+  });
+  render(<NavBar />);
+
+  const connectButton = screen.getByRole("connect");
+  expect(connectButton).toBeInTheDocument();
+
+  const connectButtonText = screen.getByText("Connected");
+  expect(connectButtonText).toBeInTheDocument();
+});
+
+test("error state shows error banner with the right message", () => {
+  UIStore.update((s) => {
+    s.connection.connected = false;
+    s.connection.loadState = {
+      type: "error",
+      error: "Failed to connect to opsdroid",
+    };
+  });
+  const { container } = render(<NavBar />);
+
+  const connectButton = screen.getByRole("connect");
+  expect(connectButton).toBeInTheDocument();
+
+  expect(container.getElementsByClassName("error-message").length).toBe(1);
+  const errorMessage = screen.getByText(
+    "Error Connecting: Failed to connect to opsdroid"
+  );
+  expect(errorMessage).toBeInTheDocument();
+
+  // Connect button should still say Disconnected
+  const buttonText = screen.getByText("Disconnected");
+  expect(buttonText).toBeInTheDocument();
+});

--- a/src/websockets/index.tsx
+++ b/src/websockets/index.tsx
@@ -54,10 +54,14 @@ export const connectToWebsocket = () => {
       }
     })
     .catch((err: Error) => {
+      let error = err.message;
+      if (err.message == "Failed to fetch") {
+        error = "Unable to request socket. Is the server running?";
+      }
       UIStore.update((s) => {
         s.connection = {
           ...s.connection,
-          ...updateConnectionStateWithError(err.message, err),
+          ...updateConnectionStateWithError(error, err),
         };
       });
       console.error("Unable to connect to websocket", err);


### PR DESCRIPTION
This PR will add the possibility to show users connection errors. If the app gets a connection error, the connected/disconnected icon will change to a warning icon and the error message will be shown below the navbar.

Here's an example of an error when we try to request a socket but opsdroid isn't running
<img width="492" alt="Screenshot 2022-06-20 at 00 33 19" src="https://user-images.githubusercontent.com/3131401/174504457-0759a648-d698-4edd-95af-1a5cb81764b6.png">

Here's an example of an error when we lose connection to opsdroid
<img width="497" alt="Screenshot 2022-06-20 at 00 33 48" src="https://user-images.githubusercontent.com/3131401/174504458-7390e991-dbbe-4cb7-ba02-66fcd1227feb.png">

Closes #3