### PR TITLE
Update error message colors and allow users to close it

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,6 +7,11 @@ import BxUnlinkIcon from "../icons/disconnectIcon";
 import WarningIcon from "../icons/warningIcon";
 import Logo from "../icons/logo";
 
+type ErrorMessageState = {
+  showErrorMessage: boolean;
+  errorMessage?: string;
+};
+
 export const NavBar = (): React.ReactElement => {
   const { showSettings, connected, client, connectedState, accentColor } =
     UIStore.useState((s) => ({
@@ -22,6 +27,11 @@ export const NavBar = (): React.ReactElement => {
     });
   };
 
+  const [errorMessageState, setErrorMessageState] =
+    React.useState<ErrorMessageState>({
+      showErrorMessage: true,
+    });
+
   const connectIfNeeded = (client?: WebsocketConnector) => {
     if (connected && client) {
       client.disconnect(1000, "Requested by user");
@@ -34,7 +44,8 @@ export const NavBar = (): React.ReactElement => {
     if (connectedState.type == "error") {
       return (
         <React.Fragment>
-          <WarningIcon className="icon" /> {"Disconnected"}
+          <WarningIcon className="icon" title={connectedState.error} />
+          {"Disconnected"}
         </React.Fragment>
       );
     } else if (connected) {
@@ -50,6 +61,23 @@ export const NavBar = (): React.ReactElement => {
         </React.Fragment>
       );
     }
+  };
+
+  if (
+    connectedState.type === "error" &&
+    connectedState.error !== errorMessageState.errorMessage
+  ) {
+    setErrorMessageState({
+      showErrorMessage: true,
+      errorMessage: connectedState.error,
+    });
+  }
+
+  const closeErrorMessage = () => {
+    setErrorMessageState({
+      showErrorMessage: false,
+      errorMessage: errorMessageState.errorMessage,
+    });
   };
 
   return (
@@ -71,11 +99,14 @@ export const NavBar = (): React.ReactElement => {
           <SettingsSharpIcon className={showSettings ? "open icon" : "icon"} />
         </button>
       </div>
-      {connectedState.type == "error" && (
+      {connectedState.type == "error" && errorMessageState.showErrorMessage ? (
         <div className="error-message">
           <p>Error Connecting: {connectedState.error}</p>
+          <button className="close-error-message" onClick={closeErrorMessage}>
+            X
+          </button>
         </div>
-      )}
+      ) : null}
     </header>
   );
 };

--- a/src/icons/warningIcon.tsx
+++ b/src/icons/warningIcon.tsx
@@ -1,7 +1,11 @@
 // icon:warning | Ant Design Icons https://ant.design/components/icon/ | Ant Design
 import * as React from "react";
 
-function WarningIcon(props: React.SVGProps<SVGSVGElement>) {
+interface WarningIconProps extends React.SVGProps<SVGSVGElement> {
+  title: string;
+}
+
+function WarningIcon(props: WarningIconProps) {
   return (
     <svg
       viewBox="0 0 1024 1024"
@@ -10,6 +14,7 @@ function WarningIcon(props: React.SVGProps<SVGSVGElement>) {
       width="1em"
       {...props}
     >
+      {props.title && <title>{props.title}</title>}
       <path d="M955.7 856l-416-720c-6.2-10.7-16.9-16-27.7-16s-21.6 5.3-27.7 16l-416 720C56 877.4 71.4 904 96 904h832c24.6 0 40-26.6 27.7-48zM480 416c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v184c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V416zm32 352a48.01 48.01 0 010-96 48.01 48.01 0 010 96z" />
     </svg>
   );

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -37,6 +37,7 @@
   --green-medium: #69D191;
   --green-light: #B9EACB;
   --green-lightest: #E0F6E8;
+  --error-background: #fb6666d4;
 
 }
 
@@ -55,7 +56,7 @@
   --navbar-background: var(--blue);
   --navbar-icon: var(--white);
   --navbar-icon-open: var(--blue-light);
-  --error-message-background: var(--grey);
+  --error-message-background: var(--error-background);
   --error-message-color: var(--dark);
   --settings-text: var(--white);
   --opsdroid-avatar: var(--blue);
@@ -76,7 +77,7 @@
     --navbar-background: var(--blue);
     --navbar-icon: var(--white);
     --navbar-icon-open: var(--blue-light);
-    --error-message-background: var(--grey);
+    --error-message-background: var(--error-background);
     --error-message-color: var(--dark);
     --settings-text: var(--dark);
     --opsdroid-avatar: var(--blue);
@@ -97,7 +98,7 @@
     --navbar-background: var(--white);
     --navbar-icon: var(--green);
     --navbar-icon-open: var(--green-light);
-    --error-message-background: var(--grey);
+    --error-message-background: var(--error-background);
     --error-message-color: var(--dark);
     --navbar-border: var(--green-lightest);
     --settings-text: var(--dark);
@@ -118,7 +119,7 @@
     --navbar-background: var(--green);
     --navbar-icon: var(--white);
     --navbar-icon-open: var(--green-light);
-    --error-message-background: var(--grey);
+    --error-message-background: var(--error-background);
     --error-message-color: var(--dark);
     --opsdroid-avatar: var(--green);
     --settings-text: var(--white);
@@ -538,6 +539,11 @@ input:checked + .slider:before {
       -ms-flex-pack: center;
           justify-content: center;
   color: var(--error-message-color);
+}
+
+.navbar .error-message .close-error-message {
+  position: absolute;
+  right: 1rem;
 }
 
 .logo {


### PR DESCRIPTION
This MR changes the background color of the error message to red since grey was a bit odd for the error. It adds a button so users can close the error message and it also adds a tooltip with the error on the warning icon so users can get information about the error after they closed the message.

Fixes: #45